### PR TITLE
Openshift origin

### DIFF
--- a/openshift-origin-rhel/scripts/masterPrep.sh
+++ b/openshift-origin-rhel/scripts/masterPrep.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+echo $(date) " - Starting Script"
 
 # Update system to latest packages and install dependencies
-yum -y update
+echo $(date) " - Install base packages and update system to latest packages"
+yum -y update --exclude=WALinuxAgent
 yum -y install wget git net-tools bind-utils iptables-services bridge-utils bash-completion pyOpenSSL httpd-tools
 
 # Install the epel repo if not already present
@@ -11,15 +13,19 @@ yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8
 yum -y clean all
 
 # Install the Ansible
+echo $(date) " - Installing Ansible"
 yum -y --enablerepo=epel install ansible 
 
 # Disable EPEL to prevent unexpected packages from being pulled in during installation.
 yum-config-manager epel --disable
 
 # Install Docker 1.10.3
+echo $(date) " - Installing Docker 1.10.3"
 yum -y install docker-1.10.3
+sed -i -e "s#^OPTIONS='--selinux-enabled'#OPTIONS='--selinux-enabled --insecure-registry 172.30.0.0/16'#" /etc/sysconfig/docker
 
 # Create thin pool logical volume for Docker
+echo $(date) " - Creating thin pool logical volume for Docker and staring service"
 echo "DEVS=/dev/sdc" >> /etc/sysconfig/docker-storage-setup
 echo "VG=docker-vg" >> /etc/sysconfig/docker-storage-setup
 docker-storage-setup

--- a/openshift-origin-rhel/scripts/nodePrep.sh
+++ b/openshift-origin-rhel/scripts/nodePrep.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+echo $(date) " - Starting Script"
 
 # Update system to latest packages and install dependencies
-yum -y update
+echo $(date) " - Install base packages and update system to latest packages"
+yum -y update --exclude=WALinuxAgent
 yum -y install wget git net-tools bind-utils iptables-services bridge-utils bash-completion pyOpenSSL httpd-tools
 
 # Install the epel repo if not already present
@@ -14,9 +16,11 @@ yum -y clean all
 yum-config-manager epel --disable
 
 # Install Docker 1.10.3
+echo $(date) " - Installing Docker 1.10.3"
 yum -y install docker-1.10.3
 
 # Create thin pool logical volume for Docker
+echo $(date) " - Creating thin pool logical volume for Docker and staring service"
 echo "DEVS=/dev/sdc" >> /etc/sysconfig/docker-storage-setup
 echo "VG=docker-vg" >> /etc/sysconfig/docker-storage-setup
 docker-storage-setup


### PR DESCRIPTION
WALinuxAgent is now being updated in CentOS 7.2 and causes failure since script extension is handled by WALinuxAgent and script fails.  This is not affecting RHEL at this point, but will eventually so this preempts issues with RHEL as well.